### PR TITLE
fix(helm): force redeployment on webhook changes

### DIFF
--- a/charts/k8tz/Chart.yaml
+++ b/charts/k8tz/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: k8tz
 description: Kubernetes admission controller to inject timezones into Pods
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.3.0"

--- a/charts/k8tz/templates/deployment.yaml
+++ b/charts/k8tz/templates/deployment.yaml
@@ -12,10 +12,11 @@ spec:
       {{- include "k8tz.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/admission-webhook.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "k8tz.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
Fixes #1 by adding checksum of the `Secret` and `MutatingWebhookConfiguration` to the pods annotations. Any change will cause redeployment.