### PR TITLE
fix(helm): downgrade helm api version for compatibility

### DIFF
--- a/charts/k8tz/Chart.yaml
+++ b/charts/k8tz/Chart.yaml
@@ -1,6 +1,5 @@
-apiVersion: v2
+apiVersion: v1
 name: k8tz
 description: Kubernetes admission controller to inject timezones into Pods
-type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "0.3.0"


### PR DESCRIPTION
No specific feature that comes from V2 is used so there is no reason to require it. This will allow users who for some reason can not upgrade their helm. 