### PR TITLE
Mark OCP installation as Done and add OCP 4.x to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ helm install k8tz k8tz/k8tz --set timezone=Europe/London
 
 ### Prerequisites
 - Helm 2 or later
-- Kubernetes 1.16 or later
+- Kubernetes 1.16+ or OpenShift 4.X
 - Permissions to use `emptyDir` or `hostPath`
 
 ### Installation
@@ -200,7 +200,7 @@ The behaviour of the controller can be changed using annotations on both `Pod` a
 
 - [ ] Support `StatefulSet` injection
 - [ ] Lookup for annotations in pods owner when possible
-- [ ] Test and document installation on OpenShift
+- [X] Test and document installation on OpenShift
 - [X] Implement `make install` for easier installation from source
 - [ ] Add VERBOSE flag to helm
 - [ ] Write verbose logs for webhook


### PR DESCRIPTION
I've successfully installed k8tz into OpenShift 4.6 and OpenShift 4.9 by helm command.
I think it is ok to remove OCP installation from TODO items.

**On OpenShift 4.9**
```
 ❯ oc run -it ubuntu --image ubuntu
If you don't see a command prompt, try pressing enter.
root@ubuntu:/# date
Wed Nov 17 05:53:04 UTC 2021
root@ubuntu:/#
root@ubuntu:/#
root@ubuntu:/# exit
exit
Session ended, resume using 'oc attach ubuntu -c ubuntu -i -t' command when the pod is running
❯
❯
❯ helm install k8tz k8tz/k8tz --set timezone=Asia/Taipei
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/jace/work/aws_ipi/auth/kubeconfig
NAME: k8tz
LAST DEPLOYED: Wed Nov 17 13:53:21 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
❯ oc get all -n k8tz
NAME                        READY   STATUS    RESTARTS   AGE
pod/k8tz-6547949b59-5cz8x   1/1     Running   0          33s

NAME           TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)   AGE
service/k8tz   ClusterIP   10.217.4.133   <none>        443/TCP   33s

NAME                   READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/k8tz   1/1     1            1           33s

NAME                              DESIRED   CURRENT   READY   AGE
replicaset.apps/k8tz-6547949b59   1         1         1       33s
❯ oc run -it ubuntu2 --image ubuntu
If you don't see a command prompt, try pressing enter.
root@ubuntu2:/# date
Wed Nov 17 13:54:37 CST 2021
root@ubuntu2:/# exit
exit
❯ oc get clusterversion
NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.9.0     True        False         33d     Cluster version is 4.9.0
```

**On OpenShift 4.6**
```
❯  oc get clusterversion
NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.6.41    True        False         38h     Cluster version is 4.6.41
❯
❯
❯ oc run -it ubuntu --image ubuntu
If you don't see a command prompt, try pressing enter.
root@ubuntu:/# date
Wed Nov 17 06:18:45 UTC 2021
root@ubuntu:/#
root@ubuntu:/# exit
exit
Session ended, resume using 'oc attach ubuntu -c ubuntu -i -t' command when the pod is running
❯
❯ helm install k8tz k8tz/k8tz --set timezone=Asia/Taipei
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/jace/work/aws_ipi/auth/kubeconfig
NAME: k8tz
LAST DEPLOYED: Wed Nov 17 14:18:59 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
❯ oc get all -n k8tz
NAME                        READY   STATUS    RESTARTS   AGE
pod/k8tz-79bc68c5fc-schqf   1/1     Running   0          14s

NAME           TYPE        CLUSTER-IP    EXTERNAL-IP   PORT(S)   AGE
service/k8tz   ClusterIP   172.30.46.5   <none>        443/TCP   14s

NAME                   READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/k8tz   1/1     1            1           14s

NAME                              DESIRED   CURRENT   READY   AGE
replicaset.apps/k8tz-79bc68c5fc   1         1         1       14s
❯
❯ oc run -it ubuntu2 --image ubuntu
If you don't see a command prompt, try pressing enter.
root@ubuntu2:/# date
Wed Nov 17 14:19:37 CST 2021
```