### PR TITLE
boolean flags must be set in their "=" form

### DIFF
--- a/charts/k8tz/Chart.yaml
+++ b/charts/k8tz/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 name: k8tz
 description: Kubernetes admission controller to inject timezones into Pods
-version: 0.4.0
-appVersion: "0.4.0"
+version: 0.4.1
+appVersion: "0.4.1"

--- a/charts/k8tz/Chart.yaml
+++ b/charts/k8tz/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 name: k8tz
 description: Kubernetes admission controller to inject timezones into Pods
 version: 0.4.1
-appVersion: "0.4.1"
+appVersion: "0.4.0"

--- a/charts/k8tz/templates/deployment.yaml
+++ b/charts/k8tz/templates/deployment.yaml
@@ -39,8 +39,7 @@ spec:
           - {{ .Values.timezone | quote }}
           - "--injection-strategy"
           - {{ .Values.injectionStrategy | quote }}
-          - "--inject"
-          - {{ .Values.injectAll | quote }}
+          - "--inject={{ .Values.injectAll }}"
           - "--bootstrap-image"
           - "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           securityContext:


### PR DESCRIPTION
Modified the chart template to use the proper form for the inject boolean flag in the webhook cmd.
Was running into the issue that setting injectAll had no effect, and k8tz was injecting into all pods regardless of the value set.

See here for a bit more information about this flag form restriction:
https://pkg.go.dev/flag#hdr-Command_line_flag_syntax

