### PR TITLE
Changed the printing method to fix the build.

### DIFF
--- a/pkg/admission/server.go
+++ b/pkg/admission/server.go
@@ -76,7 +76,7 @@ func (h *Server) Start(kubeconfigFlag string) error {
 		return fmt.Errorf("failed to setup connection with kubernetes api: %w", err)
 	}
 
-	infoLogger.Println(fmt.Sprintf("Listening on %s", h.Address))
+	infoLogger.Printf("Listening on %s\n", h.Address)
 
 	mux := http.NewServeMux()
 


### PR DESCRIPTION
# Making the build work again 
## I changed the printing method in line 79 on server.go file to make the build work again using golangci-lint run test.

```diff
- infoLogger.Println(fmt.Sprintf("Listening on %s", h.Address))
+ infoLogger.Printf("Listening on %s\n", h.Address)
```