### PR TITLE
fix: run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ ARG BINARY_LOCATION=k8tz
 COPY tzdata/zoneinfo /usr/share/zoneinfo
 COPY $BINARY_LOCATION /
 
+USER 1000
 ENTRYPOINT ["/k8tz"]

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@
 # Build Variables
 BINARY_NAME ?= k8tz
 OUT_DIR ?= build/
-VERSION ?= 0.5.0
-VERSION_SUFFIX ?= 
+VERSION ?= 0.5.1
+VERSION_SUFFIX ?= -beta0
 TARGET=/usr/local/bin
 INSTALLCMD=install -v $(OUT_DIR)$(BINARY_NAME) $(TARGET)
 BUILD_FLAGS ?= \

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	AppVersion      = "0.5.0"
-	VersionSuffix   = ""
+	AppVersion      = "0.5.1"
+	VersionSuffix   = "-beta0"
 	GitCommit       = ""
 	ImageRepository = "quay.io/k8tz/k8tz"
 )


### PR DESCRIPTION
solves "container has runAsNonRoot and image will run as root" error when pods security context specify `runAsNonRoot: true`