### PR TITLE
Remove volummount implanted by other operators to avoid conflicts

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -211,7 +211,7 @@ func (g *PatchGenerator) createEnvironmentVariablePatches(spec *corev1.PodSpec, 
 	return patches
 }
 
-func (g *PatchGenerator) removeContainerVolume(volumeMounts []corev1.VolumeMount, pathprefix string, containerId int) k8tz.Patches {
+func (g *PatchGenerator) removeContainerVolumeMounts(volumeMounts []corev1.VolumeMount, pathprefix string, containerId int) k8tz.Patches {
 	patches := k8tz.Patches{}
 	for index := len(volumeMounts) - 1; index >= 0; index-- {
 		if volumeMounts[index].MountPath == g.LocalTimePath {
@@ -266,7 +266,9 @@ func (g *PatchGenerator) createInitContainerPatches(spec *corev1.PodSpec, pathpr
 				Value: []corev1.VolumeMount{},
 			})
 		}
-		patches = append(patches, g.removeContainerVolume(spec.Containers[containerId].VolumeMounts, pathprefix, containerId)...)
+
+		patches = append(patches, g.removeContainerVolumeMounts(spec.Containers[containerId].VolumeMounts, pathprefix, containerId)...)
+
 		patches = append(patches, k8tz.Patch{
 			Op:   "add",
 			Path: fmt.Sprintf("%s/containers/%d/volumeMounts/-", pathprefix, containerId),
@@ -333,7 +335,8 @@ func (g *PatchGenerator) createHostPathPatches(spec *corev1.PodSpec, pathprefix 
 			})
 		}
 
-		patches = append(patches, g.removeContainerVolume(spec.Containers[containerId].VolumeMounts, pathprefix, containerId)...)
+		patches = append(patches, g.removeContainerVolumeMounts(spec.Containers[containerId].VolumeMounts, pathprefix, containerId)...)
+
 		patches = append(patches, k8tz.Patch{
 			Op:   "add",
 			Path: fmt.Sprintf("%s/containers/%d/volumeMounts/-", pathprefix, containerId),

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -211,7 +211,7 @@ func (g *PatchGenerator) createEnvironmentVariablePatches(spec *corev1.PodSpec, 
 	return patches
 }
 
-func (g *PatchGenerator) removeContainerVolum(volumeMounts []corev1.VolumeMount, pathprefix string, containerId int) k8tz.Patches {
+func (g *PatchGenerator) removeContainerVolume(volumeMounts []corev1.VolumeMount, pathprefix string, containerId int) k8tz.Patches {
 	patches := k8tz.Patches{}
 	for index := len(volumeMounts) - 1; index >= 0; index-- {
 		if volumeMounts[index].MountPath == g.LocalTimePath {
@@ -220,7 +220,7 @@ func (g *PatchGenerator) removeContainerVolum(volumeMounts []corev1.VolumeMount,
 				Path:  fmt.Sprintf("%s/containers/%d/volumeMounts/%d", pathprefix, containerId, index),
 				Value: "",
 			})
-		} else if volumeMounts[index].MountPath == "/usr/share/zoneinfo" {
+		} else if volumeMounts[index].MountPath == g.HostPathPrefix {
 			patches = append(patches, k8tz.Patch{
 				Op:    "remove",
 				Path:  fmt.Sprintf("%s/containers/%d/volumeMounts/%d", pathprefix, containerId, index),
@@ -266,7 +266,7 @@ func (g *PatchGenerator) createInitContainerPatches(spec *corev1.PodSpec, pathpr
 				Value: []corev1.VolumeMount{},
 			})
 		}
-		patches = append(patches, g.removeContainerVolum(spec.Containers[containerId].VolumeMounts, pathprefix, containerId)...)
+		patches = append(patches, g.removeContainerVolume(spec.Containers[containerId].VolumeMounts, pathprefix, containerId)...)
 		patches = append(patches, k8tz.Patch{
 			Op:   "add",
 			Path: fmt.Sprintf("%s/containers/%d/volumeMounts/-", pathprefix, containerId),
@@ -333,7 +333,7 @@ func (g *PatchGenerator) createHostPathPatches(spec *corev1.PodSpec, pathprefix 
 			})
 		}
 
-		patches = append(patches, g.removeContainerVolum(spec.Containers[containerId].VolumeMounts, pathprefix, containerId)...)
+		patches = append(patches, g.removeContainerVolume(spec.Containers[containerId].VolumeMounts, pathprefix, containerId)...)
 		patches = append(patches, k8tz.Patch{
 			Op:   "add",
 			Path: fmt.Sprintf("%s/containers/%d/volumeMounts/-", pathprefix, containerId),

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -865,7 +865,7 @@ func Test_removeContainerVolume(t *testing.T) {
 				HostPathPrefix: tt.fields.HostPathPrefix,
 				LocalTimePath:  "/etc/localtime",
 			}
-			got = g.removeContainerVolume(tt.args.VolumeMount, tt.args.pathprefix, tt.args.containerId)
+			got = g.removeContainerVolumeMounts(tt.args.VolumeMount, tt.args.pathprefix, tt.args.containerId)
 			if len(got) != len(tt.args.result) {
 				t.Fail()
 			}

--- a/pkg/inject/testdata/test-pod-volumeMounts-initContainer-result.yaml
+++ b/pkg/inject/testdata/test-pod-volumeMounts-initContainer-result.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8tz.io/injected: "true"
+    k8tz.io/timezone: UTC
+  name: test-pod-volumemounts
+spec:
+  containers:
+  - env:
+    - name: TZ
+      value: UTC
+    image: nginx
+    name: nginx
+    volumeMounts:
+    - mountPath: /data
+      name: data
+    - mountPath: /etc/localtime
+      name: k8tz
+      readOnly: true
+      subPath: UTC
+    - mountPath: /usr/share/zoneinfo
+      name: k8tz
+      readOnly: true
+  initContainers:
+  - args:
+    - bootstrap
+    image: testimage:0.0.0
+    name: k8tz
+    resources: {}
+    volumeMounts:
+    - mountPath: /mnt/zoneinfo
+      name: k8tz
+  volumes:
+  - hostPath:
+      path: /usr/share/zoneinfo
+    name: timezone
+  - emptyDir: {}
+    name: data
+  - emptyDir: {}
+    name: k8tz

--- a/pkg/inject/testdata/test-pod-volumeMounts-result.yaml
+++ b/pkg/inject/testdata/test-pod-volumeMounts-result.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8tz.io/injected: "true"
+    k8tz.io/timezone: UTC
+  name: test-pod-volumemounts
+spec:
+  containers:
+  - env:
+    - name: TZ
+      value: UTC
+    image: nginx
+    name: nginx
+    volumeMounts:
+    - mountPath: /data
+      name: data
+    - mountPath: /etc/localtime
+      name: k8tz
+      readOnly: true
+      subPath: UTC
+    - mountPath: /usr/share/zoneinfo
+      name: k8tz
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: /usr/share/zoneinfo
+    name: timezone
+  - emptyDir: {}
+    name: data
+  - hostPath:
+      path: /usr/share/zoneinfo
+    name: k8tz

--- a/pkg/inject/testdata/test-pod-volumeMounts.yaml
+++ b/pkg/inject/testdata/test-pod-volumeMounts.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-volumemounts
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    volumeMounts:
+      - mountPath: /etc/localtime
+        name: timezone
+        readOnly: true
+        subPath: Asia/Jerusalem
+      - mountPath: /data
+        name: data
+      - mountPath: /usr/share/zoneinfo
+        name: timezone
+        readOnly: true
+  volumes:
+    - hostPath:
+        path: /usr/share/zoneinfo
+      name: timezone
+    - emptyDir: {}
+      name: data

--- a/pkg/inject/transform_test.go
+++ b/pkg/inject/transform_test.go
@@ -218,7 +218,7 @@ func TestTransformer_Transform(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "container volumeMounts",
+			name: "test container volumeMounts",
 			fields: fields{
 				PatchGenerator: PatchGenerator{
 					Strategy:           HostPathInjectionStrategy,
@@ -230,6 +230,21 @@ func TestTransformer_Transform(t *testing.T) {
 				Inputs: []string{"testdata/test-pod-volumeMounts.yaml"},
 			},
 			golden:  "testdata/test-pod-volumeMounts-result.yaml",
+			wantErr: false,
+		},
+		{
+			name: "test initContainer",
+			fields: fields{
+				PatchGenerator: PatchGenerator{
+					Strategy:           InitContainerInjectionStrategy,
+					Timezone:           "UTC",
+					InitContainerImage: "testimage:0.0.0",
+					HostPathPrefix:     "/usr/share/zoneinfo",
+					LocalTimePath:      "/etc/localtime",
+				},
+				Inputs: []string{"testdata/test-pod-volumeMounts.yaml"},
+			},
+			golden:  "testdata/test-pod-volumeMounts-initContainer-result.yaml",
 			wantErr: false,
 		},
 	}

--- a/pkg/inject/transform_test.go
+++ b/pkg/inject/transform_test.go
@@ -217,6 +217,21 @@ func TestTransformer_Transform(t *testing.T) {
 			golden:  "testdata/list-of-uninjected-deployments-injected.yaml",
 			wantErr: false,
 		},
+		{
+			name: "container volumeMounts",
+			fields: fields{
+				PatchGenerator: PatchGenerator{
+					Strategy:           HostPathInjectionStrategy,
+					Timezone:           "UTC",
+					InitContainerImage: "testimage:0.0.0",
+					HostPathPrefix:     "/usr/share/zoneinfo",
+					LocalTimePath:      "/etc/localtime",
+				},
+				Inputs: []string{"testdata/test-pod-volumeMounts.yaml"},
+			},
+			golden:  "testdata/test-pod-volumeMounts-result.yaml",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Some operators will automatically create pods with "/etc/localtime" volumemounts, which will lead to volumemounts conflicts,

The Pod "nginx" is invalid: 
* spec.containers[0].volumeMounts[4].mountPath: Invalid value: "/etc/localtime": must be unique
* spec.containers[0].volumeMounts[5].mountPath: Invalid value: "/usr/share/zoneinfo": must be unique