### PR TITLE
refactor(build): make tzdata image as k8tz base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM scratch
-ARG BINARY_LOCATION=k8tz
+ARG TZDATA_IMAGE=quay.io/k8tz/tzdata:2022a
+FROM $TZDATA_IMAGE
 
-COPY tzdata/zoneinfo /usr/share/zoneinfo
+ARG BINARY_LOCATION=k8tz
 COPY $BINARY_LOCATION /
 
 USER 1000

--- a/tzdata/Dockerfile
+++ b/tzdata/Dockerfile
@@ -15,7 +15,6 @@
 FROM alpine:3.13 AS src
 
 ARG tzdbversion=2022a
-
 RUN \
     apk add build-base lzip && \
     wget -O tzdb.tar.lz https://data.iana.org/time-zones/releases/tzdb-$tzdbversion.tar.lz && \
@@ -25,5 +24,5 @@ RUN \
     mkdir build && \
     make TOPDIR=build install
 
-FROM alpine:3.13
+FROM scratch
 COPY --from=src /tzdb/build/usr/share/zoneinfo /usr/share/zoneinfo

--- a/tzdata/Makefile
+++ b/tzdata/Makefile
@@ -27,18 +27,7 @@ clean:
 build:
 		docker build -t $(IMAGE) --build-arg tzdbversion=$(TZDATA_VERSION) .
 
-import:
-		docker run \
-		-t \
-		-u $(shell id -u ${USER}):$(shell id -g ${USER}) \
-		-v $(mkfile_dir):/mnt/ \
-		$(IMAGE) \
-		cp -rv /usr/share/zoneinfo /mnt
-
-tar: import
-		(cd zoneinfo && tar -czvf ../tzdata-$(TZDATA_VERSION).tar.gz .)
-
 publish: build
 		docker push $(IMAGE)
 
-.PHONY: clean build import tar publish
+.PHONY: clean build publish


### PR DESCRIPTION
a bit more simple and efficient way to distribute k8tz with tzdata as separate layers.
it also solves some inconveniences with building the docker image with selinux enabled.