### PR TITLE
feat: append imagePullSecrets to injected pods to support private registries

### DIFF
--- a/charts/k8tz/templates/controller.yaml
+++ b/charts/k8tz/templates/controller.yaml
@@ -57,6 +57,10 @@ spec:
           {{- fail "CronJob injection requires kubernetes >=1.24.0-beta.0 with 'CronJobTimeZone' feature gate enabled" }}
           {{- end }}
           {{- end }}
+          {{- range $s := .Values.imagePullSecrets }}
+          - "--imagePullSecret"
+          - {{ $s.name | quote }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/cmd/inject.go
+++ b/cmd/inject.go
@@ -76,4 +76,5 @@ func init() {
 	injectCmd.Flags().StringVar(&patchGenerator.HostPathPrefix, "hostpath", patchGenerator.HostPathPrefix, "Location of TZif files on host machines")
 	injectCmd.Flags().StringVarP(&patchGenerator.LocalTimePath, "mountpath", "m", patchGenerator.LocalTimePath, "Mount path for TZif file on containers")
 	injectCmd.Flags().BoolVar(&patchGenerator.CronJobTimeZone, "cronJobTimeZone", patchGenerator.CronJobTimeZone, "Enable CronJob injection. Requires kubernetes >=1.24.0-beta.0 and the 'CronJobTimeZone' feature gate enabled (alpha)")
+	injectCmd.Flags().StringArrayVar(&patchGenerator.ImagePullSecrets, "imagePullSecret", patchGenerator.ImagePullSecrets, "Append imagePullSecret names to injected Pods (initContainer strategy only)")
 }

--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -59,5 +59,6 @@ func init() {
 	webhookCmd.Flags().StringVarP((*string)(&webhook.Handler.DefaultInjectionStrategy), "injection-strategy", "s", string(webhook.Handler.DefaultInjectionStrategy), "Default injection strategy if not specified explicitly (hostPath/initContainer)")
 	webhookCmd.Flags().BoolVar(&webhook.Handler.InjectByDefault, "inject", webhook.Handler.InjectByDefault, "Whether injection is enabled by default or should be requested by annotation")
 	webhookCmd.Flags().BoolVar(&webhook.Handler.CronJobTimeZone, "cronJobTimeZone", webhook.Handler.CronJobTimeZone, "Enable CronJob injection. Requires kubernetes >=1.24.0-beta.0 and the 'CronJobTimeZone' feature gate enabled (alpha)")
+	webhookCmd.Flags().StringArrayVar(&webhook.Handler.ImagePullSecrets, "imagePullSecret", webhook.Handler.ImagePullSecrets, "Append imagePullSecret names to injected Pods (initContainer strategy only)")
 	webhookCmd.Flags().BoolVar(&webhook.Verbose, "verbose", webhook.Verbose, "Print more verbose logs for debugging")
 }

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -45,6 +45,7 @@ type RequestsHandler struct {
 	HostPathPrefix           string
 	LocalTimePath            string
 	CronJobTimeZone          bool
+	ImagePullSecrets         []string
 	clientset                kubernetes.Interface
 }
 
@@ -57,6 +58,7 @@ func NewRequestsHandler() RequestsHandler {
 		HostPathPrefix:           inject.DefaultHostPathPrefix,
 		LocalTimePath:            inject.DefaultLocalTimePath,
 		CronJobTimeZone:          false,
+		ImagePullSecrets:         []string{},
 	}
 }
 
@@ -235,6 +237,7 @@ func (h *RequestsHandler) lookupPod(namespace string, pod *corev1.Pod) (*inject.
 		InitContainerImage: h.BootstrapImage,
 		HostPathPrefix:     h.HostPathPrefix,
 		LocalTimePath:      h.LocalTimePath,
+		ImagePullSecrets:   h.ImagePullSecrets,
 	}, nil
 }
 
@@ -280,6 +283,7 @@ func (h *RequestsHandler) lookupCronJob(namespace string, cronJob *batchv1.CronJ
 		HostPathPrefix:     h.HostPathPrefix,
 		LocalTimePath:      h.LocalTimePath,
 		CronJobTimeZone:    h.CronJobTimeZone,
+		ImagePullSecrets:   h.ImagePullSecrets,
 	}, nil
 }
 

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -876,3 +876,75 @@ func Test_removeContainerVolume(t *testing.T) {
 		})
 	}
 }
+
+func Test_imagePullSecretsNameExists(t *testing.T) {
+	type args struct {
+		imagePullSecrets []corev1.LocalObjectReference
+		name             string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "null secrets list",
+			args: args{
+				imagePullSecrets: nil,
+				name:             "someSecretName",
+			},
+			want: false,
+		},
+		{
+			name: "empty secrets list",
+			args: args{
+				imagePullSecrets: []corev1.LocalObjectReference{},
+				name:             "someSecretName",
+			},
+			want: false,
+		},
+		{
+			name: "secrets list with non existing secrets",
+			args: args{
+				imagePullSecrets: []corev1.LocalObjectReference{
+					{
+						Name: "someOtherSecretName1",
+					},
+					{
+						Name: "someOtherSecretName2",
+					},
+					{
+						Name: "someOtherSecretName3",
+					},
+				},
+				name: "someSecretName",
+			},
+			want: false,
+		},
+		{
+			name: "secrets list with existing secret",
+			args: args{
+				imagePullSecrets: []corev1.LocalObjectReference{
+					{
+						Name: "someOtherSecretName1",
+					},
+					{
+						Name: "someSecretName",
+					},
+					{
+						Name: "someOtherSecretName3",
+					},
+				},
+				name: "someSecretName",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := imagePullSecretsNameExists(tt.args.imagePullSecrets, tt.args.name); got != tt.want {
+				t.Errorf("imagePullSecretsNameExists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/inject/testdata/simple-pod-with-conflicting-imagePullSecrets-result.yaml
+++ b/pkg/inject/testdata/simple-pod-with-conflicting-imagePullSecrets-result.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8tz.io/injected: "true"
+    k8tz.io/timezone: America/Jamaica
+  name: nginx
+spec:
+  containers:
+  - env:
+    - name: TZ
+      value: America/Jamaica
+    image: nginx
+    name: nginx
+    volumeMounts:
+    - mountPath: /etc/localtime
+      name: k8tz
+      readOnly: true
+      subPath: America/Jamaica
+    - mountPath: /usr/share/zoneinfo
+      name: k8tz
+      readOnly: true
+  imagePullSecrets:
+  - name: myPrivateRegistryPullSecret
+  initContainers:
+  - args:
+    - bootstrap
+    image: quay.io/k8tz/k8tz:0.0.1-beta2
+    name: k8tz
+    resources: {}
+    volumeMounts:
+    - mountPath: /mnt/zoneinfo
+      name: k8tz
+  volumes:
+  - emptyDir: {}
+    name: k8tz

--- a/pkg/inject/testdata/simple-pod-with-conflicting-imagePullSecrets.yaml
+++ b/pkg/inject/testdata/simple-pod-with-conflicting-imagePullSecrets.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - image: nginx
+    name: nginx
+  imagePullSecrets:
+  - name: myPrivateRegistryPullSecret

--- a/pkg/inject/testdata/simple-pod-with-existing-imagePullSecrets-result.yaml
+++ b/pkg/inject/testdata/simple-pod-with-existing-imagePullSecrets-result.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8tz.io/injected: "true"
+    k8tz.io/timezone: America/Jamaica
+  name: nginx
+spec:
+  containers:
+  - env:
+    - name: TZ
+      value: America/Jamaica
+    image: nginx
+    name: nginx
+    volumeMounts:
+    - mountPath: /etc/localtime
+      name: k8tz
+      readOnly: true
+      subPath: America/Jamaica
+    - mountPath: /usr/share/zoneinfo
+      name: k8tz
+      readOnly: true
+  imagePullSecrets:
+  - name: somePullSecret
+  - name: myPrivateRegistryPullSecret
+  initContainers:
+  - args:
+    - bootstrap
+    image: quay.io/k8tz/k8tz:0.0.1-beta2
+    name: k8tz
+    resources: {}
+    volumeMounts:
+    - mountPath: /mnt/zoneinfo
+      name: k8tz
+  volumes:
+  - emptyDir: {}
+    name: k8tz

--- a/pkg/inject/testdata/simple-pod-with-existing-imagePullSecrets.yaml
+++ b/pkg/inject/testdata/simple-pod-with-existing-imagePullSecrets.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+spec:
+  containers:
+  - image: nginx
+    name: nginx
+  imagePullSecrets:
+  - name: somePullSecret

--- a/pkg/inject/testdata/test-pod-hostPath-imagePullSecrets-1.yaml
+++ b/pkg/inject/testdata/test-pod-hostPath-imagePullSecrets-1.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8tz.io/injected: "true"
+    k8tz.io/timezone: America/Jamaica
+  name: nginx
+spec:
+  containers:
+  - env:
+    - name: TZ
+      value: America/Jamaica
+    image: nginx
+    name: nginx
+    volumeMounts:
+    - mountPath: /etc/localtime
+      name: k8tz
+      readOnly: true
+      subPath: America/Jamaica
+    - mountPath: /usr/share/zoneinfo
+      name: k8tz
+      readOnly: true
+  volumes:
+  - hostPath:
+      path: /usr/share/zoneinfo
+    name: k8tz

--- a/pkg/inject/testdata/test-pod-initContainer-imagePullSecrets-1.yaml
+++ b/pkg/inject/testdata/test-pod-initContainer-imagePullSecrets-1.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8tz.io/injected: "true"
+    k8tz.io/timezone: America/Jamaica
+  name: nginx
+spec:
+  containers:
+  - env:
+    - name: TZ
+      value: America/Jamaica
+    image: nginx
+    name: nginx
+    volumeMounts:
+    - mountPath: /etc/localtime
+      name: k8tz
+      readOnly: true
+      subPath: America/Jamaica
+    - mountPath: /usr/share/zoneinfo
+      name: k8tz
+      readOnly: true
+  imagePullSecrets:
+  - name: myPrivateRegistryPullSecret
+  initContainers:
+  - args:
+    - bootstrap
+    image: quay.io/k8tz/k8tz:0.0.1-beta2
+    name: k8tz
+    resources: {}
+    volumeMounts:
+    - mountPath: /mnt/zoneinfo
+      name: k8tz
+  volumes:
+  - emptyDir: {}
+    name: k8tz

--- a/pkg/inject/transform_test.go
+++ b/pkg/inject/transform_test.go
@@ -247,6 +247,78 @@ func TestTransformer_Transform(t *testing.T) {
 			golden:  "testdata/test-pod-volumeMounts-initContainer-result.yaml",
 			wantErr: false,
 		},
+		{
+			name: "patch pod with initContainer and imagePullSecrets",
+			fields: fields{
+				PatchGenerator: PatchGenerator{
+					Strategy:           InitContainerInjectionStrategy,
+					Timezone:           "America/Jamaica",
+					InitContainerImage: "quay.io/k8tz/k8tz:0.0.1-beta2",
+					HostPathPrefix:     "/usr/share/zoneinfo",
+					LocalTimePath:      "/etc/localtime",
+					ImagePullSecrets: []string{
+						"myPrivateRegistryPullSecret",
+					},
+				},
+				Inputs: []string{"testdata/simple-pod.yaml"},
+			},
+			golden:  "testdata/test-pod-initContainer-imagePullSecrets-1.yaml",
+			wantErr: false,
+		},
+		{
+			name: "patch pod with initContainer and existing other imagePullSecrets",
+			fields: fields{
+				PatchGenerator: PatchGenerator{
+					Strategy:           InitContainerInjectionStrategy,
+					Timezone:           "America/Jamaica",
+					InitContainerImage: "quay.io/k8tz/k8tz:0.0.1-beta2",
+					HostPathPrefix:     "/usr/share/zoneinfo",
+					LocalTimePath:      "/etc/localtime",
+					ImagePullSecrets: []string{
+						"myPrivateRegistryPullSecret",
+					},
+				},
+				Inputs: []string{"testdata/simple-pod-with-existing-imagePullSecrets.yaml"},
+			},
+			golden:  "testdata/simple-pod-with-existing-imagePullSecrets-result.yaml",
+			wantErr: false,
+		},
+		{
+			name: "patch pod with initContainer and conflicting imagePullSecrets",
+			fields: fields{
+				PatchGenerator: PatchGenerator{
+					Strategy:           InitContainerInjectionStrategy,
+					Timezone:           "America/Jamaica",
+					InitContainerImage: "quay.io/k8tz/k8tz:0.0.1-beta2",
+					HostPathPrefix:     "/usr/share/zoneinfo",
+					LocalTimePath:      "/etc/localtime",
+					ImagePullSecrets: []string{
+						"myPrivateRegistryPullSecret",
+					},
+				},
+				Inputs: []string{"testdata/simple-pod-with-conflicting-imagePullSecrets.yaml"},
+			},
+			golden:  "testdata/simple-pod-with-conflicting-imagePullSecrets-result.yaml",
+			wantErr: false,
+		},
+		{
+			name: "patch pod with hostPath and imagePullSecrets - should ignore ImagePullSecrets",
+			fields: fields{
+				PatchGenerator: PatchGenerator{
+					Strategy:           HostPathInjectionStrategy,
+					Timezone:           "America/Jamaica",
+					InitContainerImage: "quay.io/k8tz/k8tz:0.0.1-beta2",
+					HostPathPrefix:     "/usr/share/zoneinfo",
+					LocalTimePath:      "/etc/localtime",
+					ImagePullSecrets: []string{
+						"myPrivateRegistryPullSecret",
+					},
+				},
+				Inputs: []string{"testdata/simple-pod.yaml"},
+			},
+			golden:  "testdata/test-pod-hostPath-imagePullSecrets-1.yaml",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The main problem here is that the secret may (and probably will) not be available in every namespace and not in the same name always. So I am still wondering if this is the right approach or the user should do it manually. Maybe it should be optional and not enabled by default(?). Maybe configurable with some annotations?

TODO:
- [ ] Decide if this is the correct way
- [x] Implement patch functions
- [x] Add tests
- [x] Helm chart support
- [ ] Add documentation

Close #49 