### PR TITLE
docs: fix workflow badges url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Timezone Controller
 
-![Build Workflow Status](https://img.shields.io/github/workflow/status/k8tz/k8tz/Go)
+![Build Workflow Status](https://img.shields.io/github/actions/workflow/status/k8tz/k8tz/go.yaml?branch=master)
 [![Go Report Card](https://img.shields.io/badge/go%20report-A+-brightgreen.svg?style=flat)](https://goreportcard.com/report/github.com/k8tz/k8tz)
 [![codecov](https://codecov.io/gh/k8tz/k8tz/branch/master/graph/badge.svg?token=3HEoptX1C0)](https://codecov.io/gh/k8tz/k8tz)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/k8tz/k8tz)](go.mod)

--- a/charts/k8tz/README.md
+++ b/charts/k8tz/README.md
@@ -1,7 +1,7 @@
 # Kubernetes Timezone Controller - Helm Chart
 
-![Lint Chart Workflow Status](https://img.shields.io/github/workflow/status/k8tz/k8tz/Lint%20Helm%20Charts?label=Lint)
-![Build Chart Workflow Status](https://img.shields.io/github/workflow/status/k8tz/k8tz/Release%20Helm%20Charts?label=Release)
+![Lint Chart Workflow Status](https://img.shields.io/github/actions/workflow/status/k8tz/k8tz/helm-lint.yaml?branch=master&label=Lint)
+![Build Chart Workflow Status](https://img.shields.io/github/actions/workflow/status/k8tz/k8tz/helm-release.yaml?branch=master&label=Release)
 ![Helm 2 Compatible](https://img.shields.io/badge/Helm%202-Compatible-blue)
 ![Helm 2 Compatible](https://img.shields.io/badge/Helm%203-Compatible-blue)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/k8tz)](https://artifacthub.io/packages/search?repo=k8tz)


### PR DESCRIPTION
update the badges url after scheme changed and became broken. as described in: https://github.com/badges/shields/issues/8671