### PR TITLE
Allow configure tls-cipher-suites and tls-min-version via command line params

### DIFF
--- a/cmd/webhook.go
+++ b/cmd/webhook.go
@@ -17,8 +17,11 @@ limitations under the License.
 package cmd
 
 import (
+	"strings"
+
 	"github.com/k8tz/k8tz/pkg/admission"
 	"github.com/spf13/cobra"
+	cliflag "k8s.io/component-base/cli/flag"
 )
 
 var webhook = admission.NewAdmissionServer()
@@ -51,6 +54,17 @@ func init() {
 
 	webhookCmd.Flags().StringVar(&webhook.TLSCertFile, "tls-crt", webhook.TLSCertFile, "TLS Certificate file")
 	webhookCmd.Flags().StringVar(&webhook.TLSKeyFile, "tls-key", webhook.TLSKeyFile, "TLS Key file")
+	tlsCipherPreferredValues := cliflag.PreferredTLSCipherNames()
+	tlsCipherInsecureValues := cliflag.InsecureTLSCipherNames()
+	webhookCmd.Flags().StringSliceVar(&webhook.TLSCipherSuites, "tls-cipher-suites", webhook.TLSCipherSuites,
+		"Comma-separated list of cipher suites for the server. "+
+			"If omitted, the default Go cipher suites will be used. \n"+
+			"Preferred values: "+strings.Join(tlsCipherPreferredValues, ", ")+". \n"+
+			"Insecure values: "+strings.Join(tlsCipherInsecureValues, ", ")+".")
+	tlsPossibleVersions := cliflag.TLSPossibleVersions()
+	webhookCmd.Flags().StringVar(&webhook.TLSMinVersion, "tls-min-version", webhook.TLSMinVersion,
+		"Minimum TLS version supported. "+
+			"Possible values: "+strings.Join(tlsPossibleVersions, ", "))
 	webhookCmd.Flags().StringVar(&webhook.Address, "addr", webhook.Address, "Webhook bind address")
 	webhookCmd.Flags().StringVarP(&webhook.Handler.DefaultTimezone, "timezone", "t", webhook.Handler.DefaultTimezone, "Default timezone if not specified explicitly")
 	webhookCmd.Flags().StringVar(&webhook.Handler.BootstrapImage, "bootstrap-image", webhook.Handler.BootstrapImage, "initContainer bootstrap image")

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -471,6 +473,8 @@ k8s.io/apimachinery v0.26.1 h1:8EZ/eGJL+hY/MYCNwhmDzVqq2lPl3N3Bo8rvweJwXUQ=
 k8s.io/apimachinery v0.26.1/go.mod h1:tnPmbONNJ7ByJNz9+n9kMjNP8ON+1qoAIIC70lztu74=
 k8s.io/client-go v0.26.1 h1:87CXzYJnAMGaa/IDDfRdhTzxk/wzGZ+/HUQpqgVSZXU=
 k8s.io/client-go v0.26.1/go.mod h1:IWNSglg+rQ3OcvDkhY6+QLeasV4OYHDjdqeWkDQZwGE=
+k8s.io/component-base v0.26.1 h1:4ahudpeQXHZL5kko+iDHqLj/FSGAEUnSVO0EBbgDd+4=
+k8s.io/component-base v0.26.1/go.mod h1:VHrLR0b58oC035w6YQiBSbtsf0ThuSwXP+p5dD/kAWU=
 k8s.io/klog/v2 v2.80.1 h1:atnLQ121W371wYYFawwYx1aEY2eUfs4l3J72wtgAwV4=
 k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 h1:+70TFaan3hfJzs+7VK2o+OGxg8HsuBr/5f6tVAjDu6E=

--- a/pkg/admission/server.go
+++ b/pkg/admission/server.go
@@ -97,6 +97,23 @@ func (h *Server) Start(kubeconfigFlag string) error {
 				}
 				return &cert, nil
 			},
+			CipherSuites: []uint16{
+				// TLSv1.0 & TLSv1.1
+				tls.TLS_RSA_WITH_AES_128_CBC_SHA, //nolint:gosec
+				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				// TLSv1.2
+				tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+				// TLSv1.3
+				tls.TLS_AES_128_GCM_SHA256,
+				tls.TLS_AES_256_GCM_SHA384,
+				tls.TLS_CHACHA20_POLY1305_SHA256,
+			},
 		},
 	}
 

--- a/pkg/admission/server.go
+++ b/pkg/admission/server.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	cliflag "k8s.io/component-base/cli/flag"
 )
 
 const (
@@ -45,11 +46,13 @@ var (
 )
 
 type Server struct {
-	TLSCertFile string
-	TLSKeyFile  string
-	Address     string
-	Handler     RequestsHandler
-	Verbose     bool
+	TLSCertFile     string
+	TLSKeyFile      string
+	TLSCipherSuites []string
+	TLSMinVersion   string
+	Address         string
+	Handler         RequestsHandler
+	Verbose         bool
 }
 
 func NewAdmissionServer() *Server {
@@ -73,9 +76,16 @@ func (h *Server) Start(kubeconfigFlag string) error {
 		verboseLogger.SetOutput(os.Stderr)
 		verboseLogger.Printf("server=%+v", *h)
 	}
-
-	err := h.Handler.InitializeClientset(kubeconfigFlag)
+	minTLSVersion, err := cliflag.TLSVersion(h.TLSMinVersion)
 	if err != nil {
+		return err
+	}
+	tlsCipherSuites, err := cliflag.TLSCipherSuites(h.TLSCipherSuites)
+	if err != nil {
+		return err
+	}
+
+	if err = h.Handler.InitializeClientset(kubeconfigFlag); err != nil {
 		return fmt.Errorf("failed to setup connection with kubernetes api: %w", err)
 	}
 
@@ -97,23 +107,8 @@ func (h *Server) Start(kubeconfigFlag string) error {
 				}
 				return &cert, nil
 			},
-			CipherSuites: []uint16{
-				// TLSv1.0 & TLSv1.1
-				tls.TLS_RSA_WITH_AES_128_CBC_SHA, //nolint:gosec
-				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-				// TLSv1.2
-				tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-				// TLSv1.3
-				tls.TLS_AES_128_GCM_SHA256,
-				tls.TLS_AES_256_GCM_SHA384,
-				tls.TLS_CHACHA20_POLY1305_SHA256,
-			},
+			CipherSuites: tlsCipherSuites,
+			MinVersion:   minTLSVersion,
 		},
 	}
 


### PR DESCRIPTION
Fixes #74 


```sh
> go run main.go webhook --help                        
Starts k8tz's Kubernetes mutating admission controller webhook server.

The webhook will listen to requests from Kubernetes and reply
with list of json patches for kubernetes to perform in order
to have the timezone injected to containers.

TLS certificate and private key is required to receive requests
from kubernetes controllers. The certificate should have SAN
and DNS that reflects the webhooks service FQDN, e.g:
webhook.k8tz.svc.

Injection defaults can be controlled via flags such as '-t'
to change the default timezone; or '-s' to change the injection
strategy.

Usage:
  k8tz webhook [flags]

Flags:
      --addr string                 Webhook bind address (default ":8443")
      --bootstrap-image string      initContainer bootstrap image (default "quay.io/k8tz/k8tz:0.13.1")
      --cronJobTimeZone             Enable CronJob injection. Requires kubernetes >=1.24.0-beta.0 and the 'CronJobTimeZone' feature gate enabled (alpha)
  -h, --help                        help for webhook
      --hostPathPrefix string       Location of zoneinfo on host machines (default "/usr/share/zoneinfo")
      --inject                      Whether injection is enabled by default or should be requested by annotation (default true)
  -s, --injection-strategy string   Default injection strategy if not specified explicitly (hostPath/initContainer) (default "initContainer")
      --localTimePath string        Mount path for TZif file on containers (default "/etc/localtime")
  -t, --timezone string             Default timezone if not specified explicitly (default "UTC")
      --tls-cipher-suites strings   Comma-separated list of cipher suites for the server. If omitted, the default Go cipher suites will be used. 
                                    Preferred values: TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256, TLS_RSA_WITH_AES_128_CBC_SHA, TLS_RSA_WITH_AES_128_GCM_SHA256, TLS_RSA_WITH_AES_256_CBC_SHA, TLS_RSA_WITH_AES_256_GCM_SHA384. 
                                    Insecure values: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_RC4_128_SHA, TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_RSA_WITH_RC4_128_SHA, TLS_RSA_WITH_3DES_EDE_CBC_SHA, TLS_RSA_WITH_AES_128_CBC_SHA256, TLS_RSA_WITH_RC4_128_SHA.
      --tls-crt string              TLS Certificate file (default "/run/secrets/tls/tls.crt")
      --tls-key string              TLS Key file (default "/run/secrets/tls/tls.key")
      --tls-min-version string      Minimum TLS version supported. Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
      --verbose                     Print more verbose logs for debugging

Global Flags:
      --kube-config string   Path to kubeconfig file
```


reference: [kubelet/app/server.go](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/server.go#L1101])