### PR TITLE
fix(chart): Allow usage of helm built-in namespaces

### DIFF
--- a/charts/k8tz/Chart.yaml
+++ b/charts/k8tz/Chart.yaml
@@ -3,6 +3,7 @@ name: k8tz
 description: Kubernetes admission controller to inject timezones into Pods and CronJobs
 version: 0.14.0
 appVersion: "0.14.0"
+kubeVersion: ">= 1.21.0"
 icon: https://github.com/k8tz/k8tz/raw/master/assets/k8tz-icon-transparent.png
 home: http://k8tz.io
 sources:

--- a/charts/k8tz/templates/admission-webhook.yaml
+++ b/charts/k8tz/templates/admission-webhook.yaml
@@ -1,4 +1,4 @@
-{{- $fqdn := printf "%s.%s.svc" (include "k8tz.serviceName" .) .Values.namespace }}
+{{- $fqdn := printf "%s.%s.svc" (include "k8tz.serviceName" .) .Release.Namespace }}
 {{- $ca := genSelfSignedCert $fqdn (list) (list $fqdn) 5114 }}
 {{- if (not .Values.webhook.certManager.enabled) -}}
 apiVersion: v1
@@ -7,7 +7,7 @@ data:
   tls.key: {{ ternary (b64enc (trim $ca.Key)) (b64enc (trim .Values.webhook.keyPEM)) (empty .Values.webhook.keyPEM) }}
 kind: Secret
 metadata:
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   creationTimestamp: null
   name: {{ include "k8tz.fullname" . }}-tls
   labels:
@@ -20,7 +20,7 @@ metadata:
   name: {{ include "k8tz.fullname" . }}
   {{- if .Values.webhook.certManager.enabled }}
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Values.namespace }}/{{ include "k8tz.fullname" . }}-tls
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "k8tz.fullname" . }}-tls
   {{- end }}
   labels:
     {{- include "k8tz.labels" . | nindent 4 }}
@@ -28,22 +28,20 @@ webhooks:
   - name: admission-controller.k8tz.io
     namespaceSelector:
       matchExpressions:
-      - key: k8tz.io/controller-namespace
-        operator: NotIn
-        values: ["true"]
-      {{- if .Values.webhook.ignoredNamespaces }}
       - key: kubernetes.io/metadata.name
         operator: NotIn
         values:
+        - {{ .Release.Namespace }}
+        {{- if .Values.webhook.ignoredNamespaces }}
         {{- toYaml .Values.webhook.ignoredNamespaces | nindent 8 }}
-      {{- end }}
+        {{- end }}
     sideEffects: None
     failurePolicy: {{ .Values.webhook.failurePolicy }}
     admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       service:
         name: {{ include "k8tz.serviceName" . }}
-        namespace: {{ .Values.namespace }}
+        namespace: {{ .Release.Namespace }}
         path: "/"
         port: {{ .Values.service.port }}
       {{- if (not .Values.webhook.certManager.enabled) }}

--- a/charts/k8tz/templates/certificate.yaml
+++ b/charts/k8tz/templates/certificate.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.webhook.certManager.enabled -}}
-{{- $fqdn := printf "%s.%s.svc" (include "k8tz.serviceName" .) .Values.namespace }}
+{{- $fqdn := printf "%s.%s.svc" (include "k8tz.serviceName" .) .Release.Namespace }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "k8tz.fullname" . }}-tls
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "k8tz.labels" . | nindent 4 }}
 spec:

--- a/charts/k8tz/templates/controller.yaml
+++ b/charts/k8tz/templates/controller.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: {{ .Values.kind }}
 metadata:
   name: {{ include "k8tz.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "k8tz.labels" . | nindent 4 }}
 spec:
@@ -115,7 +115,7 @@ spec:
           - "--secret-name"
           - {{ include "k8tz.fullname" . }}-tls
           - "--secret-namespace"
-          - {{ .Values.namespace }}
+          - {{ .Release.Namespace }}
           securityContext:
             {{- include "k8tz.securityContext" . | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/k8tz/templates/namespace.yaml
+++ b/charts/k8tz/templates/namespace.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.namespace }}
-  labels:
-    k8tz.io/controller-namespace: "true"
-    {{- include "k8tz.labels" . | nindent 4 }}

--- a/charts/k8tz/templates/rbac.yaml
+++ b/charts/k8tz/templates/rbac.yaml
@@ -21,7 +21,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ include "k8tz.serviceAccountName" . }}
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io

--- a/charts/k8tz/templates/service.yaml
+++ b/charts/k8tz/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "k8tz.serviceName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "k8tz.labels" . | nindent 4 }}
 spec:

--- a/charts/k8tz/templates/serviceaccount.yaml
+++ b/charts/k8tz/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "k8tz.serviceAccountName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "k8tz.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/k8tz/templates/tests/test-connection.yaml
+++ b/charts/k8tz/templates/tests/test-connection.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "k8tz.fullname" . }}-health-test"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "k8tz.labels" . | nindent 4 }}
   annotations:

--- a/charts/k8tz/values.yaml
+++ b/charts/k8tz/values.yaml
@@ -3,7 +3,6 @@
 kind: Deployment
 replicaCount: 1
 
-namespace: k8tz
 injectionStrategy: initContainer
 timezone: UTC
 injectAll: true


### PR DESCRIPTION
This patch should resolve https://github.com/k8tz/k8tz/issues/5#issuecomment-950362169 using the existing ignore-namespace feature to resolve both. True, it's not backwards compatible, and if required, we can achieve this, but it should allow to use this helm chart, without requiring the chart to be used to create the namespace.

BREAKING CHANGE: Drop in-chart namespace creation

(One of the main reason to implement this change for me, is that I don't leave namespace creation to helm charts due to enforcing PSS and alike.)