### PR TITLE
fix: namespaces with restricted security need explicit `runAsNonRoot`…

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -330,6 +330,7 @@ func (g *PatchGenerator) createInitContainerPatches(spec *corev1.PodSpec, pathpr
 						"ALL",
 					},
 				},
+				RunAsNonRoot: &True,
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{


### PR DESCRIPTION
See #98.

Explicitely set `runAsNonRoot` on container for namespaces with enforced security as restricted.