### PR TITLE
fix: revert volume name back to "k8tz" after it changed by mistake to initContainer name

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -267,7 +267,7 @@ func (g *PatchGenerator) createInitContainerPatches(spec *corev1.PodSpec, pathpr
 		Op:   "add",
 		Path: fmt.Sprintf("%s/volumes/-", pathprefix),
 		Value: corev1.Volume{
-			Name: g.InitContainerName,
+			Name: "k8tz",
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},

--- a/pkg/inject/testdata/initcontainerstrategy-custom-name.json
+++ b/pkg/inject/testdata/initcontainerstrategy-custom-name.json
@@ -8,7 +8,7 @@
     "op": "add",
     "path": "/spec/volumes/-",
     "value": {
-      "name": "k8tz-init",
+      "name": "k8tz",
       "emptyDir": {}
     }
   },

--- a/pkg/inject/testdata/initcontainerstrategy-verbose.json
+++ b/pkg/inject/testdata/initcontainerstrategy-verbose.json
@@ -8,7 +8,7 @@
     "op": "add",
     "path": "/spec/volumes/-",
     "value": {
-      "name": "k8tz-init",
+      "name": "k8tz",
       "emptyDir": {}
     }
   },


### PR DESCRIPTION
It looks like in #84 we mistakenly added this bug along with the ability to override initContainer name (even the tests was wrong, but i missed it).

Specifically at: https://github.com/k8tz/k8tz/pull/84/files#diff-9e807cd458968007dc7aef4120a31173123f070de548fa46090ef88fd2b9c2a1R261

Fixes #101 