### PR TITLE
build(goreleaser): fix recent deprecation notices and validation warnings

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 dist: build
 before:
   hooks:
@@ -49,7 +50,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-snapshot"
+  version_template: "{{ incpatch .Version }}-snapshot"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
fix the warning in https://goreleaser.com/deprecations/#snapshotname_template

and adds the requested version label